### PR TITLE
Improve cleanup commands

### DIFF
--- a/net.blockattack.game.yaml
+++ b/net.blockattack.game.yaml
@@ -11,7 +11,12 @@ finish-args:
   - --share=ipc
   - --socket=x11
   - --socket=pulseaudio
-
+cleanup:
+  - /include
+  - /lib/cmake
+  - /share/man
+  - "*.la"
+  - "*.a"
 modules:
   - shared-modules/physfs/physfs.json
 


### PR DESCRIPTION
Remove the development-related files to reduce the installed size.

```
189M  ./include
80K   ./lib/cmake
12K   ./share/man
```

The installed size was reduced from **160 MB** to **9.5 MB**.