### PR TITLE
Update the runtime version to from 24.08 to 25.08, and more

### DIFF
--- a/net.blockattack.game.yaml
+++ b/net.blockattack.game.yaml
@@ -1,6 +1,6 @@
 app-id: net.blockattack.game
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: blockattack
 rename-icon: blockattack
@@ -19,6 +19,8 @@ cleanup:
   - "*.a"
 modules:
   - shared-modules/physfs/physfs.json
+  - shared-modules/SDL2/SDL2_image.json
+  - shared-modules/SDL2/SDL2_ttf.json
 
   - name: boost
     buildsystem: simple


### PR DESCRIPTION
- Update the runtime version to 25.08
- Use required SDL2 modules from shared-modules